### PR TITLE
Add the requirement of 'scipy' package.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,4 +6,5 @@ setup(name='phasepack',
       author='Alistair Muldal',
       author_email='alistair.muldal@pharm.ox.ac.uk',
       url='https://github.com/alimuldal/phasepack',
+      install_requires=['scipy'],
       packages=['phasepack'])


### PR DESCRIPTION
Add the requirement of 'scipy' package.

This line is important: when install the phasepack package with pip, the setup must install the 'scipy' as a requirement. Otherwise, the phasepack doesn't work.